### PR TITLE
Add exit_on_error option

### DIFF
--- a/doc/imapfilter_config.5
+++ b/doc/imapfilter_config.5
@@ -117,6 +117,12 @@ takes a
 .Vt boolean
 as a value.  Default is
 .Dq true .
+.It Va exit_on_error
+When this option is enabled, a login failure will stop the rest of the 
+script from running. This variable takes a
+.Vt boolean
+as a value.  Default is
+.Dq false .
 .It Va expunge
 Normally, messages are marked for deletion and are actually deleted when the
 mailbox is closed.  When this option is enabled, messages are expunged

--- a/src/core.c
+++ b/src/core.c
@@ -137,6 +137,11 @@ ifcore_login(lua_State *lua)
 
 	r = request_login(s, p, get_table_string("ssl"), u, w);
 
+	/* If the login has failed, and exit_on_error is set, throw an exception */
+	if (-1 == r && get_option_boolean("exit_on_error")) {
+		luaL_error(lua, "Login has failed, stopping");		
+	}
+
 	lua_pop(lua, 1);
 
 	if (r == STATUS_RESPONSE_NONE)

--- a/src/options.lua
+++ b/src/options.lua
@@ -3,3 +3,4 @@
 options.cache = true
 options.close = false
 options.info = true
+options.exit_on_error = false


### PR DESCRIPTION
When my password has expired, or other IMAP issues occur, this option will cause the script to exit after the first failure, rather then trying to re-login and getting the same error for every action in my config.lua
