### PR TITLE
Adding a simple packaging utility

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,2 +1,5 @@
 all install uninstall clean:
 	cd src && $(MAKE) $@
+
+tarbz2 :
+	./mkpackage.sh `git describe --tags HEAD`

--- a/mkpackage.sh
+++ b/mkpackage.sh
@@ -1,0 +1,23 @@
+#!/bin/sh
+#
+# Simple script to make tar.bz2 files from git tags
+#
+# Copyright (c) 2013 David Sommerseth
+# See LICENSE for details
+#
+
+if [ $# = 0 ]; then
+    echo "Usage: $0 <tag name>"
+    exit
+fi
+
+# Check if tag exists
+git tag -l | grep -q $1
+if [ $? -ne 0 ];then
+    echo "No such tag: $1"
+    exit 1
+fi
+
+# Create a tar.bz2 archive based on the tag
+git archive -v --format=tar --prefix=imapfilter-$1/ $1 | bzip2 -9c > imapfilter-$1.tar.bz2
+


### PR DESCRIPTION
The added script will generate a tar.bz2 file based on a git tag.
When using the 'tarbz2' make target, it will make a package
based on the currently checked-out git tag.

If you try to run 'make tarbz2' on a commit which is not
identifiable as a tag, it will fail.  This is by design, to
ensure only tagged versions can result in a tar.bz2 file.

Signed-off-by: David Sommerseth davids@redhat.com
