### PR TITLE
Read config from stdin if config is specified as '-'

### DIFF
--- a/doc/imapfilter.1
+++ b/doc/imapfilter.1
@@ -24,7 +24,7 @@ The command line options of
 are as follows:
 .Bl -tag -width Ds
 .It Fl c Ar configfile
-Path to the configuration file.  The default is
+Path to the configuration file, or - to read from stdin.  The default is
 .Pa $HOME/.imapfilter/config.lua .
 .It Fl d Ar debugfile
 File that contains debugging information about the full communication with the

--- a/src/lua.c
+++ b/src/lua.c
@@ -78,7 +78,7 @@ start_lua()
 		    "=<command line>") || lua_pcall(lua, 0, LUA_MULTRET, 0))
 			fatal(ERROR_CONFIG, "%s\n", lua_tostring(lua, -1));
 	} else {
-		if (luaL_loadfile(lua, opts.config))
+		if (luaL_loadfile(lua, strcmp(opts.config, "-") == 0 ? NULL : opts.config))
 			fatal(ERROR_CONFIG, "%s\n", lua_tostring(lua, -1));
 		lua_pushcfunction(lua, traceback_handler);
 		lua_insert(lua, 1);


### PR DESCRIPTION
This is a standard option in command line utilities and can make some things much easier.

Examples:

``` bash
imapfilter -c ./config.lua # old way, still works
imapfilter -c - < ./config.lua # read from stdin
sed -e 's/user1/user2/' -e 's/pass1/pass2/' ./config.lua | imapfilter -c - # handy in bash loops, etc etc
```

For example I'm going to use it to use the same lua script on multiple accounts by just having sed replace the usernames and passwords for me while not writing the new config to the filesystem each time.

Thanks for the nice software!
