### PR TITLE
Ignore results for chdir call in system.c (line 208)

### DIFF
--- a/src/system.c
+++ b/src/system.c
@@ -13,6 +13,7 @@
 
 #include "imapfilter.h"
 
+#pragma GCC diagnostic ignored "-Wunused-result"
 
 static int ifsys_echo(lua_State *lua);
 static int ifsys_noecho(lua_State *lua);


### PR DESCRIPTION
This addressed the issue of the warning from the chdir("/") call at line 208 in src/system.c.

 In addition I used the following debian build arguments: 
make INCDIRS=-I/usr/include/lua5.2 LIBLUA=-llua5.2
