### PR TITLE
Validate SSL certificates #56

### DIFF
--- a/doc/imapfilter.1
+++ b/doc/imapfilter.1
@@ -23,6 +23,13 @@ The command line options of
 .Xr imapfilter 1
 are as follows:
 .Bl -tag -width Ds
+.It Fl a Ar directory
+The directory containing the SSL CA files.  Most Linux distributions come with the
+ca-certificates package already installed.  Any certificate which cannot be validated
+using the CA certificates in this directory will be validated using the certificates
+file.  The default is
+.Pa /etc/ssl/certs
+which is suitable for most Linux systems.
 .It Fl c Ar configfile
 Path to the configuration file to read, or the
 .Sq -

--- a/src/cert.c
+++ b/src/cert.c
@@ -44,7 +44,7 @@ get_cert(session *ssn)
 	/* If certificate validated normally, accept it */
 	verify = SSL_get_verify_result(ssn->sslconn);
 	verbose("SSL: Certificate subject = %s\n", X509_NAME_oneline(X509_get_subject_name(cert), NULL, 0));
-	verbose("SSL: Certificate verify result = %d\n", verify);
+	verbose("SSL: Certificate verify result = %d\t%s\n", verify, X509_verify_cert_error_string(verify));
 	
 	/* Verify results:
 	 * 0	X509_V_OK					Accept certificate
@@ -80,8 +80,10 @@ get_cert(session *ssn)
 				goto fail;
 			break;
 		}
+
+		verbose("SSL: Certificate matched against '%s'\n", get_filepath("certificates"));
 	}
-	
+
 	X509_free(cert);
 
 	return 0;

--- a/src/imapfilter.c
+++ b/src/imapfilter.c
@@ -49,17 +49,21 @@ main(int argc, char *argv[])
 	opts.interactive = 0;
 	opts.log = NULL;
 	opts.config = NULL;
+	opts.ca_dir = "/etc/ssl/certs";
 	opts.oneline = NULL;
 	opts.debug = NULL;
 
 	env.home = NULL;
 	env.pathmax = -1;
 
-	while ((c = getopt(argc, argv, "Vc:d:e:il:v?")) != -1) {
+	while ((c = getopt(argc, argv, "Va:c:d:e:il:v?")) != -1) {
 		switch (c) {
 		case 'V':
 			version();
 			/* NOTREACHED */
+			break;
+		case 'a':
+			opts.ca_dir = optarg;
 			break;
 		case 'c':
 			opts.config = optarg;
@@ -111,16 +115,16 @@ main(int argc, char *argv[])
 	tls11ctx = SSL_CTX_new(TLSv1_1_client_method());
 	tls12ctx = SSL_CTX_new(TLSv1_2_client_method());
 #endif
-	if (exists_dir((char *)SSL_TRUSTSTORE) == 0)
+	if (exists_dir(opts.ca_dir) == 1)
 	{
-		SSL_CTX_load_verify_locations(ssl3ctx, NULL, SSL_TRUSTSTORE);
-		SSL_CTX_load_verify_locations(ssl23ctx, NULL, SSL_TRUSTSTORE);
-		SSL_CTX_load_verify_locations(tls1ctx, NULL, SSL_TRUSTSTORE);
+		SSL_CTX_load_verify_locations(ssl3ctx, NULL, opts.ca_dir);
+		SSL_CTX_load_verify_locations(ssl23ctx, NULL, opts.ca_dir);
+		SSL_CTX_load_verify_locations(tls1ctx, NULL, opts.ca_dir);
 #if OPENSSL_VERSION_NUMBER >= 0x01000100fL
-		SSL_CTX_load_verify_locations(tls11ctx, NULL, SSL_TRUSTSTORE);
-		SSL_CTX_load_verify_locations(tls12ctx, NULL, SSL_TRUSTSTORE);
+		SSL_CTX_load_verify_locations(tls11ctx, NULL, opts.ca_dir);
+		SSL_CTX_load_verify_locations(tls12ctx, NULL, opts.ca_dir);
 #endif
-		verbose("SSL: Certicates will be verified against issuers in '%s'\n", SSL_TRUSTSTORE);
+		verbose("SSL: Certicates will be verified against issuers in '%s'\n", opts.ca_dir);
 	}
 
 

--- a/src/imapfilter.h
+++ b/src/imapfilter.h
@@ -13,9 +13,6 @@
 
 #include "session.h"
 
-/* Truststore where SSL certs will be verified	*/
-#define SSL_TRUSTSTORE			"/etc/ssl/certs"
-
 /* Fatal error exit codes. */
 #define ERROR_SIGNAL			1
 #define ERROR_CONFIG			2
@@ -67,6 +64,7 @@ typedef struct options {
 	int interactive;	/* Act as an interpreter. */
 	char *log;		/* Log file for error messages. */
 	char *config;		/* Configuration file. */
+	char *ca_dir;		/* CA truststore */
 	char *oneline;		/* One line of program/configuration. */
 	char *debug;		/* Debug file. */
 } options;

--- a/src/socket.c
+++ b/src/socket.c
@@ -160,6 +160,8 @@ open_secure_connection(session *ssn)
 	if (get_option_boolean("certificates") && get_cert(ssn) == -1)
 		goto fail;
 
+	verbose("SSL: Connected to '%s:%s' as '%s' using %s\n", ssn->server, ssn->port, ssn->username, SSL_get_version(ssn->sslconn));
+	
 	return 0;
 
 fail:


### PR DESCRIPTION
I don't know what happened to the code for my last fix to verify certificates, but here is a new minimal version. It contains 34 new lines of code and 20 lines which have been indented but not otherwise changed.  The aim is verify certificates which can be verified, but otherwise fall back to using `~/.imapfilter/certificates`

How it works:
- Every linux system should have a directory `/etc/ssl/certs` which links to CA certificates.  The actual certicates are stored in differing directories, depending on the distro.  I've tested this with Debian (and thus Ubuntu/Mint etc) and CentOs.
- OpenSSL always validates the certificate when a SSL connection occurs.  If the `/etc/ssl/certs` directory exists, it's added to the SSL context `imapfilter.c` using `SSL_CTX_load_verify_locations()`.  If the `/etc/ssl/certs` directory does not exist, then fall back to using `~/.imapfilter/certificates`
- In `get_cert()`, the result of the SSL handshake is checked.  There are three possible outcomes
  - The certificate validated correctly against `/etc/ssl/certs` and the `get_cert()` returns 0
  - A self-signed certificate or a certificate with an unknown issuer (or where `/etc/ssl/certs` doesn't exist) has been presented, in which case validate the cert as usual against `~/.imapfilter/certificates`
  - All other certificates will be rejected as invalid
