### PR TITLE
Ensure password prompt is always written

### DIFF
--- a/src/auxiliary.lua
+++ b/src/auxiliary.lua
@@ -14,6 +14,7 @@ function get_password(prompt)
     else
         io.write('Enter password: ')
     end
+    io.flush()
     ifsys.noecho()
     local p = io.read()
     ifsys.echo()


### PR DESCRIPTION
On many systems, the password prompt is not automatically flushed from the output buffer, as it does not end in a newline. This gives the program the appearance of hanging and consuming all keyboard input. Manually flushing takes care of this.