### PR TITLE
Define DESTDIR and PREFIX conditionally

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -1,5 +1,5 @@
-DESTDIR =
-PREFIX = /usr/local
+DESTDIR ?=
+PREFIX ?= /usr/local
 BINDIR = $(PREFIX)/bin
 SHAREDIR = $(PREFIX)/share/imapfilter
 MANDIR = $(PREFIX)/man


### PR DESCRIPTION
The current Makefile defines `DESTDIR` and `PREFIX` unconditionally, which breaks staged installs (like package managers do).