### PR TITLE
regexec() bug fixed with UTF8 locale and 8bit encoding in message

### DIFF
--- a/src/imapfilter.c
+++ b/src/imapfilter.c
@@ -44,8 +44,6 @@ main(int argc, char *argv[])
 	int c;
 	char *cafile = NULL, *capath = NULL;
 
-	setlocale(LC_CTYPE, "");
-
 	opts.verbose = 0;
 	opts.interactive = 0;
 	opts.log = NULL;


### PR DESCRIPTION
If there is a message with '8bit' encoding, ru_RU.UTF8 locale breaks regexec. It seems that default C locale is enough.