### PR TITLE
Set SNI to server name

### DIFF
--- a/src/socket.c
+++ b/src/socket.c
@@ -140,6 +140,12 @@ open_secure_connection(session *ssn)
 
 	if (!(ssn->sslconn = SSL_new(ctx)))
 		goto fail;
+#if OPENSSL_VERSION_NUMBER >= 0x1000000fL
+	SSL_set_tlsext_host_name(ssn->sslconn, ssn->server);
+#else
+	debug("unable to set SNI to %s due to OpenSSL version < 1.0.0\n",
+	      ssn->server);
+#endif
 
 	SSL_set_fd(ssn->sslconn, ssn->socket);
 


### PR DESCRIPTION
Without it, imapfilter becomes incompatible with Gmail's IMAP servers.

Quoting from openssl-project:

    TLS 1.3 has raised the status of SNI from optional to "mandatory to
    implement". What this means that is that implementations must
    support it, but it stops of mandating SNI outright.  Clients SHOULD
    send SNI, when applicable, and servers MAY require SNI.

    Along comes 1.3, and suddenly some server operators have become
    particularly keen on enforcing all sorts of constraints that at
    first blush look rather aggressive.  Specifically, the Google
    SMTP servers serving millions of domains (including gmail.com),
    now only do TLS 1.3 when SNI is presented, and when SNI is missing,
    not only negotiate TLS 1.2, but use an unexpected self-signed cert
    chain that validating senders will fail to authenticate, and others
    may find perplexing in their logs.  (Thanks to Phil Pennock, Bcc'd
    for reporting this on the exim-dev list).

See the following mailing list threads and bug reports for details:

    https://mta.openssl.org/pipermail/openssl-project/2018-April/000623.html
    https://bugzilla.redhat.com/show_bug.cgi?id=1611815
    https://bugs.debian.org/907193