### PR TITLE
Add -H option to ignore ssl hostname verification

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,1 +1,2 @@
 Lefteris Chatzimparmpas <lefcha@fastmail.com>
+John 'Warthog9' Hawley <warthog9@eaglescrag.net>

--- a/doc/imapfilter.1
+++ b/doc/imapfilter.1
@@ -39,6 +39,8 @@ May be used to enter
 of configuration, while it is also possible to pipe a full configuration as a
 string.
 When this option is used, a configuration file will not be loaded.
+.It Fl H
+Disables SSL hostname checking
 .It Fl i
 Enters interactive mode after executing the configuration file.
 .It Fl l Ar logfile

--- a/src/imapfilter.c
+++ b/src/imapfilter.c
@@ -61,6 +61,7 @@ main(int argc, char *argv[])
 
 	opts.verbose = 0;
 	opts.interactive = 0;
+	opts.ignoresslhostname = 0;
 	opts.dryrun = 0;
 	opts.log = NULL;
 	opts.config = NULL;
@@ -76,7 +77,7 @@ main(int argc, char *argv[])
 	env.home = NULL;
 	env.pathmax = -1;
 
-	while ((c = getopt(argc, argv, "Vc:d:e:il:nt:v?")) != -1) {
+	while ((c = getopt(argc, argv, "Vc:d:e:Hil:nt:v?")) != -1) {
 		switch (c) {
 		case 'V':
 			version();
@@ -93,6 +94,9 @@ main(int argc, char *argv[])
 			break;
 		case 'i':
 			opts.interactive = 1;
+			break;
+		case 'H':
+			opts.ignoresslhostname = 1;
 			break;
 		case 'l':
 			opts.log = optarg;
@@ -245,7 +249,7 @@ void
 usage(void)
 {
 
-	fprintf(stderr, "usage: imapfilter [-inVv] [-c configfile] "
+	fprintf(stderr, "usage: imapfilter [-HinVv] [-c configfile] "
 	    "[-d debugfile] [-e 'command']\n"
 	    "\t\t  [-l logfile] [-t truststore]\n");
 

--- a/src/imapfilter.h
+++ b/src/imapfilter.h
@@ -70,6 +70,7 @@
 typedef struct options {
 	int verbose;		/* Verbose mode. */
 	int interactive;	/* Act as an interpreter. */
+	int ignoresslhostname;	/* Ignores the SSL hostname verification check */
         int dryrun;             /* Don't send commands that do changes. */
 	char *log;		/* Log file for error messages. */
 	char *config;		/* Configuration file. */

--- a/src/socket.c
+++ b/src/socket.c
@@ -18,6 +18,9 @@
 #include "session.h"
 
 
+extern options opts;
+
+
 #if OPENSSL_VERSION_NUMBER >= 0x1010000fL
 SSL_CTX *sslctx = NULL;
 #else
@@ -161,7 +164,9 @@ open_secure_connection(session *ssn)
 			goto fail;
 		}
 
-		SSL_set_verify(ssn->sslconn, SSL_VERIFY_PEER, NULL);
+		//JAH
+		if (!opts.ignoresslhostname)
+			SSL_set_verify(ssn->sslconn, SSL_VERIFY_PEER, NULL);
 #elif OPENSSL_VERSION_NUMBER >= 0x10002000L
 		X509_VERIFY_PARAM *param = SSL_get0_param(ssn->sslconn);
 		X509_VERIFY_PARAM_set_hostflags(param,


### PR DESCRIPTION
With v2.6.14 the option to more strictly verify hostnames was added
this is great for the most part except when you are trying to
do something with a self signed cert, or accessing something
via localhost and thus the certificate you are attempting to
verify is not going to match I.E. localhost != example.org

This gives a rather heavy handed lever to turn off that
checking.  This should probably, in the long run, be a
per-account setting so that you don't disable it universally
needlessly

Signed-off-by: John 'Warthog9' Hawley <warthog9@eaglescrag.net>