### PR TITLE
add -p option to write a pid file

### DIFF
--- a/doc/imapfilter.1
+++ b/doc/imapfilter.1
@@ -11,6 +11,7 @@
 .Op Fl d Ar debugfile
 .Op Fl e Ar 'command'
 .Op Fl l Ar logfile
+.Op Fl p Ar pidfile
 .Op Fl t Ar truststore
 .Sh DESCRIPTION
 .Nm
@@ -63,6 +64,8 @@ file will be used.  The default CA directory is
 .Pa /etc/ssl/certs/ ,
 and the default CA file is
 .Pa /etc/ssl/cert.pem .
+.It Fl p Ar pidfile
+Write the process ID to this file on startup, and delete it on exit.
 .It Fl V
 Displays version and copyright information.
 .It Fl v

--- a/src/file.c
+++ b/src/file.c
@@ -11,7 +11,7 @@
 #include "imapfilter.h"
 #include "pathnames.h"
 
-
+extern options opts;
 extern environment env;
 
 
@@ -156,4 +156,31 @@ get_filepath(char *fname)
 	snprintf(fp, n + 1, "%s/%s", env.home, fname);
 
 	return fp;
+}
+
+void
+write_pidfile(void)
+{
+    FILE *pidfile;
+
+    if (opts.pidfile != NULL) {
+        pidfile = fopen(opts.pidfile, "w");
+        if (pidfile == NULL) {
+            error("unable to write PID to \'%s\' (%d: %s)", errno, strerror(errno));
+        }
+        else {
+            fprintf(pidfile, "%d", getpid());
+            fclose(pidfile);
+        }
+    }
+}
+
+void
+delete_pidfile(void)
+{
+    if (opts.pidfile != NULL) {
+        if (unlink(opts.pidfile) == -1) {
+            error("unable to delete PID file \'%s\' (%d: %s)", errno, strerror(errno));
+        }
+    }
 }

--- a/src/imapfilter.c
+++ b/src/imapfilter.c
@@ -76,7 +76,7 @@ main(int argc, char *argv[])
 	env.home = NULL;
 	env.pathmax = -1;
 
-	while ((c = getopt(argc, argv, "Vc:d:e:il:nt:v?")) != -1) {
+	while ((c = getopt(argc, argv, "Vc:d:e:il:np:t:v?")) != -1) {
 		switch (c) {
 		case 'V':
 			version();
@@ -100,6 +100,9 @@ main(int argc, char *argv[])
 		case 'n':
 			opts.dryrun = 1;
 			break;
+		case 'p':
+		    opts.pidfile = optarg;
+		    break;
 		case 't':
 			opts.truststore = optarg;
 			break;
@@ -120,6 +123,8 @@ main(int argc, char *argv[])
 	catch_signals();
 	ignore_user_signals();
 	open_log();
+    write_pidfile();
+
 	if (opts.config == NULL)
 		opts.config = get_filepath("config.lua");
 
@@ -231,6 +236,8 @@ main(int argc, char *argv[])
 
 	xfree(env.home);
 
+	delete_pidfile();
+
 	close_log();
 	close_debug();
 
@@ -247,7 +254,7 @@ usage(void)
 
 	fprintf(stderr, "usage: imapfilter [-inVv] [-c configfile] "
 	    "[-d debugfile] [-e 'command']\n"
-	    "\t\t  [-l logfile] [-t truststore]\n");
+	    "\t\t  [-l logfile] [-p pidfile] [-t truststore]\n");
 
 	exit(0);
 }

--- a/src/imapfilter.h
+++ b/src/imapfilter.h
@@ -74,6 +74,7 @@ typedef struct options {
 	char *log;		/* Log file for error messages. */
 	char *config;		/* Configuration file. */
 	char *oneline;		/* One line of program/configuration. */
+	char *pidfile;      /* write a pidfile (useful for systemd template files */
 	char *debug;		/* Debug file. */
         char *truststore;       /* CA TrustStore. */
 } options;
@@ -102,6 +103,8 @@ int exists_dir(char *fname);
 int create_file(char *fname, mode_t mode);
 int get_pathmax(void);
 char *get_filepath(char *fname);
+void write_pidfile(void);
+void delete_pidfile(void);
 
 /*	log.c		*/
 void verbose(const char *info,...);

--- a/src/log.c
+++ b/src/log.c
@@ -127,6 +127,7 @@ fatal(unsigned int errnum, const char *fmt,...)
 		close_connection(s);
 	}
 
+	delete_pidfile();
 	close_log();
 	close_debug();
 


### PR DESCRIPTION
Used by the imapfilter systemd template file I'm working on.

Systemd template files use the 'imapfilter@<user>.service pattern, making it easy to run a separate imapfilter instance per user.