### PR TITLE
Add Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+FROM ubuntu:latest
+
+COPY . /imapfilter
+
+RUN apt update && \
+    DEBIAN_FRONTEND="noninteractive" apt install -y build-essential ca-certificates libpcre2-dev liblua5.3-dev libssl-dev && \
+    cd /imapfilter && \
+    make INCDIRS=-I/usr/include/lua5.3/ LIBDIRS=-L/usr/lib/x86_64-linux-gnu/ LIBLUA=-llua5.3 && \
+    make install && \
+    apt remove -y build-essential && \
+    apt autoremove -y && \
+    rm -R /imapfilter
+
+CMD /usr/local/bin/imapfilter -c /config.lua


### PR DESCRIPTION
I came up with a simple dockerfile for imapfilter, might be helpful for easy deployment on servers. All you really need to do is set a bind mount pointing to your config file (see below).

I pushed an image built from that dockerfile to dockerhub. In docker-compose, you can run it with:

```
version: "3"
services:
  imapfilter:
    restart: always
    image: linusseelinger/imapfilter
    container_name: imapfilter
    volumes:
      - /your/config/imapfilter_config.lua:/config.lua
```

Would be great to have an officially supported docker setup, maybe this can serve as a starting point!