### PR TITLE
Session use after free

### DIFF
--- a/src/request.c
+++ b/src/request.c
@@ -177,11 +177,11 @@ request_login(session **ssnptr, const char *server, const char *port, const
 	if (!*ssnptr) {
 		ssn = *ssnptr = session_new();
 
-		ssn->server = server;
-		ssn->port = port;
-		ssn->username = user;
-		ssn->password = pass;
-		ssn->oauth2 = oauth2;
+		ssn->server = xstrdup(server);
+		ssn->port = xstrdup(port);
+		ssn->username = user ? xstrdup(user) : NULL;
+		ssn->password = pass ? xstrdup(pass) : NULL;
+		ssn->oauth2 = oauth2 ? xstrdup(oauth2) : NULL;
 
 		if (ssl)
 			ssn->sslproto = ssl;

--- a/src/session.c
+++ b/src/session.c
@@ -63,6 +63,30 @@ session_destroy(session *ssn)
 
 	sessions = list_remove(sessions, ssn);
 
+	if (ssn->server) {
+		xfree(ssn->server);
+		ssn->server = NULL;
+	}
+	if (ssn->port) {
+		xfree(ssn->port);
+		ssn->port = NULL;
+	}
+	if (ssn->username) {
+		xfree(ssn->username);
+		ssn->username = NULL;
+	}
+	if (ssn->password) {
+		xfree(ssn->password);
+		ssn->password = NULL;
+	}
+	if (ssn->oauth2) {
+		xfree(ssn->oauth2);
+		ssn->oauth2 = NULL;
+	}
+	if (ssn->server) {
+		xfree(ssn->server);
+		ssn->server = NULL;
+	}
 	if (ssn->ns.prefix) {
 		xfree(ssn->ns.prefix);
 		ssn->ns.prefix = NULL;


### PR DESCRIPTION
The C core stores pointers to the Lua string passed when login in to an account. However Lua's strings are only valid until they are popped from stack.

Thus once eg lua code changes the password, by eg changing (the private) member:

```
Account._account.password
```

the the prior (dangling) reference may no longer point to the correct memory location leading to a segmentation fault.

The code in the pull request stores copies for xstrdup instead.

A similar issue happens when reconnection fails during `options.recover = true` runs. Here the issue is that the C core's request_login function tears down the session object if login fails. However this then produces dangling pointers since it will try to recover again using the same (now invalid) pointer to a partially torn down session.

This commit is not really a nice fix, mostly I would thin one may have to have a `login` and `relogin` function to avoid the extra flag I introduced. Not sure what would best fit into imapfilter's code pilosophy.