### PR TITLE
Adding UTF-8 support conforming to RFC 6855

### DIFF
--- a/src/imapfilter.h
+++ b/src/imapfilter.h
@@ -33,6 +33,9 @@
 #define CAPABILITY_CHILDREN		0x04
 #define CAPABILITY_IDLE			0x08
 #define CAPABILITY_XOAUTH2		0x10
+#define CAPABILITY_ENABLE		0x20
+#define CAPABILITY_UTF8_ACCEPT	0x80
+#define CAPABILITY_UTF8_ONLY	0xC0 /* Implies UTF8=ACCEPT */
 
 /* Status responses and response codes. */
 #define STATUS_BYE			-2
@@ -135,8 +138,8 @@ const char *xstrcasestr(const char *haystack, const char *needle);
 char *xstrncpy(char *dest, const char *src, size_t size);
 
 /*	namespace.c	*/
-const char *apply_namespace(const char *mbox, char *prefix, char delim);
-const char *reverse_namespace(const char *mbox, char *prefix, char delim);
+const char *apply_namespace(const char *mbox, char *prefix, char delim, char utf8_accept_enabled);
+const char *reverse_namespace(const char *mbox, char *prefix, char delim, char utf8_accept_enabled);
 
 /*	pcre.c		*/
 LUALIB_API int luaopen_ifre(lua_State *lua);

--- a/src/namespace.c
+++ b/src/namespace.c
@@ -23,7 +23,7 @@ const char *reverse_conversion(const char *mbox);
  * by the mail server, from internal to mail server format.
  */
 const char *
-apply_namespace(const char *mbox, char *prefix, char delim)
+apply_namespace(const char *mbox, char *prefix, char delim, char utf8_accept_enabled)
 {
 	int n;
 	char *c;
@@ -32,7 +32,9 @@ apply_namespace(const char *mbox, char *prefix, char delim)
 	if (!strcasecmp(mbox, "INBOX"))
 		return mbox;
 
-	m = apply_conversion(mbox);
+	m = mbox;
+	if (!utf8_accept_enabled)
+		m = apply_conversion(mbox);
 
 	if ((prefix == NULL && delim == '\0') ||
 	    (prefix == NULL && delim == '/'))
@@ -60,7 +62,7 @@ apply_namespace(const char *mbox, char *prefix, char delim)
  * the mail server, from mail server format to internal format.
  */
 const char *
-reverse_namespace(const char *mbox, char *prefix, char delim)
+reverse_namespace(const char *mbox, char *prefix, char delim, char utf8_accept_enabled)
 {
 	int n, o;
 	char *c;
@@ -69,8 +71,11 @@ reverse_namespace(const char *mbox, char *prefix, char delim)
 		return mbox;
 
 	if ((prefix == NULL && delim == '\0') ||
-	    (prefix == NULL && delim == '/'))
-		return reverse_conversion(mbox);
+	    (prefix == NULL && delim == '/')) {
+		if (!utf8_accept_enabled)
+			return reverse_conversion(mbox);
+		return mbox;
+	}
 
 	buffer_reset(&nbuf);
 

--- a/src/request.c
+++ b/src/request.c
@@ -396,7 +396,8 @@ request_fetchfast(session *ssn, const char *mesg, char **flags, char **date,
 {
 	int t, r;
 
-	TRY(t = send_request(ssn, "UID FETCH %s FAST", mesg));
+	/*TRY(t = send_request(ssn, "UID FETCH %s FAST", mesg));*/
+	TRY(t = send_request(ssn, "UID FETCH %s (FLAGS INTERNALDATE RFC822.SIZE)", mesg));
 	TRY(r = response_fetchfast(ssn, t, flags, date, size));
 
 	return r;

--- a/src/request.c
+++ b/src/request.c
@@ -212,6 +212,17 @@ request_login(session **ssnptr, const char *server, const char *port, const char
 	TRY(t = send_request(ssn, "CAPABILITY"));
 	TRY(response_capability(ssn, t));
 
+	if (!strcasecmp(get_option_string("charset"), "UTF-8") ||
+		!strcasecmp(get_option_string("charset"), "UTF8")) {
+		if (ssn->capabilities & CAPABILITY_ENABLE &&
+			ssn->capabilities & CAPABILITY_UTF8_ACCEPT) {
+			TRY(t = send_request(ssn, "ENABLE UTF8=ACCEPT"));
+			TRY(r = response_generic(ssn, t));
+			if (r == STATUS_OK)
+				ssn->utf8_accept_enabled = 1;
+		}
+	}
+
 	if (ssn->capabilities & CAPABILITY_NAMESPACE &&
 	    get_option_boolean("namespace")) {
 		TRY(t = send_request(ssn, "NAMESPACE"));
@@ -251,7 +262,7 @@ request_status(session *ssn, const char *mbox, unsigned int *exists, unsigned
 	int t, r;
 	const char *m;
 
-	m = apply_namespace(mbox, ssn->ns.prefix, ssn->ns.delim);
+	m = apply_namespace(mbox, ssn->ns.prefix, ssn->ns.delim, ssn->utf8_accept_enabled);
 
 	if (ssn->protocol == PROTOCOL_IMAP4REV1) {
 		TRY(t = send_request(ssn,
@@ -275,7 +286,7 @@ request_select(session *ssn, const char *mbox)
 	int t, r;
 	const char *m;
 
-	m = apply_namespace(mbox, ssn->ns.prefix, ssn->ns.delim);
+	m = apply_namespace(mbox, ssn->ns.prefix, ssn->ns.delim, ssn->utf8_accept_enabled);
 
 	TRY(t = send_request(ssn, "SELECT \"%s\"", m));
 	TRY(r = response_select(ssn, t));
@@ -327,7 +338,7 @@ request_list(session *ssn, const char *refer, const char *name, char **mboxs,
 	int t, r;
 	const char *n;
 
-	n = apply_namespace(name, ssn->ns.prefix, ssn->ns.delim);
+	n = apply_namespace(name, ssn->ns.prefix, ssn->ns.delim, ssn->utf8_accept_enabled);
 	
 	TRY(t = send_request(ssn, "LIST \"%s\" \"%s\"", refer, n));
 	TRY(r = response_list(ssn, t, mboxs, folders));
@@ -346,7 +357,7 @@ request_lsub(session *ssn, const char *refer, const char *name, char **mboxs,
 	int t, r;
 	const char *n;
 
-	n = apply_namespace(name, ssn->ns.prefix, ssn->ns.delim);
+	n = apply_namespace(name, ssn->ns.prefix, ssn->ns.delim, ssn->utf8_accept_enabled);
 
 	TRY(t = send_request(ssn, "LSUB \"%s\" \"%s\"", refer, n));
 	TRY(r = response_list(ssn, t, mboxs, folders));
@@ -364,7 +375,7 @@ request_search(session *ssn, const char *criteria, const char *charset, char
 {
 	int t, r;
 
-	if (charset != NULL && *charset != '\0') {
+	if (charset != NULL && *charset != '\0' && !ssn->utf8_accept_enabled) {
 		TRY(t = send_request(ssn, "UID SEARCH CHARSET \"%s\" %s",
 		    charset, criteria));
 	} else {
@@ -567,7 +578,7 @@ request_copy(session *ssn, const char *mesg, const char *mbox)
 	if (opts.dryrun)
 		return STATUS_DRYRUN;
 
-	m = apply_namespace(mbox, ssn->ns.prefix, ssn->ns.delim);
+	m = apply_namespace(mbox, ssn->ns.prefix, ssn->ns.delim, ssn->utf8_accept_enabled);
 
 	TRY(t = send_request(ssn, "UID COPY %s \"%s\"", mesg, m));
 	TRY(r = response_generic(ssn, t));
@@ -601,7 +612,7 @@ request_append(session *ssn, const char *mbox, const char *mesg, size_t
 	if (opts.dryrun)
 		return STATUS_DRYRUN;
 
-	m = apply_namespace(mbox, ssn->ns.prefix, ssn->ns.delim);
+	m = apply_namespace(mbox, ssn->ns.prefix, ssn->ns.delim, ssn->utf8_accept_enabled);
 
 	TRY(t = send_request(ssn, "APPEND \"%s\"%s%s%s%s%s%s {%d}", m,
 	    (flags ? " (" : ""), (flags ? flags : ""),
@@ -650,7 +661,7 @@ request_create(session *ssn, const char *mbox)
 	if (opts.dryrun)
 		return STATUS_DRYRUN;
 
-	m = apply_namespace(mbox, ssn->ns.prefix, ssn->ns.delim);
+	m = apply_namespace(mbox, ssn->ns.prefix, ssn->ns.delim, ssn->utf8_accept_enabled);
 
 	TRY(t = send_request(ssn, "CREATE \"%s\"", m));
 	TRY(r = response_generic(ssn, t));
@@ -671,7 +682,7 @@ request_delete(session *ssn, const char *mbox)
 	if (opts.dryrun)
 		return STATUS_DRYRUN;
 
-	m = apply_namespace(mbox, ssn->ns.prefix, ssn->ns.delim);
+	m = apply_namespace(mbox, ssn->ns.prefix, ssn->ns.delim, ssn->utf8_accept_enabled);
 
 	TRY(t = send_request(ssn, "DELETE \"%s\"", m));
 	TRY(r = response_generic(ssn, t));
@@ -692,8 +703,8 @@ request_rename(session *ssn, const char *oldmbox, const char *newmbox)
 	if (opts.dryrun)
 		return STATUS_DRYRUN;
 
-	o = xstrdup(apply_namespace(oldmbox, ssn->ns.prefix, ssn->ns.delim));
-	n = xstrdup(apply_namespace(newmbox, ssn->ns.prefix, ssn->ns.delim));
+	o = xstrdup(apply_namespace(oldmbox, ssn->ns.prefix, ssn->ns.delim, ssn->utf8_accept_enabled));
+	n = xstrdup(apply_namespace(newmbox, ssn->ns.prefix, ssn->ns.delim, ssn->utf8_accept_enabled));
 
 	TRY(t = send_request(ssn, "RENAME \"%s\" \"%s\"", o, n));
 	TRY(r = response_generic(ssn, t));
@@ -714,7 +725,7 @@ request_subscribe(session *ssn, const char *mbox)
 	if (opts.dryrun)
 		return STATUS_DRYRUN;
 
-	m = apply_namespace(mbox, ssn->ns.prefix, ssn->ns.delim);
+	m = apply_namespace(mbox, ssn->ns.prefix, ssn->ns.delim, ssn->utf8_accept_enabled);
 
 	TRY(t = send_request(ssn, "SUBSCRIBE \"%s\"", m));
 	TRY(r = response_generic(ssn, t));
@@ -735,7 +746,7 @@ request_unsubscribe(session *ssn, const char *mbox)
 	if (opts.dryrun)
 		return STATUS_DRYRUN;
 
-	m = apply_namespace(mbox, ssn->ns.prefix, ssn->ns.delim);
+	m = apply_namespace(mbox, ssn->ns.prefix, ssn->ns.delim, ssn->utf8_accept_enabled);
 
 	TRY(t = send_request(ssn, "UNSUBSCRIBE \"%s\"", m));
 	TRY(r = response_generic(ssn, t));

--- a/src/response.c
+++ b/src/response.c
@@ -350,6 +350,12 @@ response_capability(session *ssn, int tag)
 			ssn->capabilities |= CAPABILITY_IDLE;
 		if (xstrcasestr(s, "AUTH=XOAUTH2"))
 			ssn->capabilities |= CAPABILITY_XOAUTH2;
+		if (xstrcasestr(s, "ENABLE"))
+			ssn->capabilities |= CAPABILITY_ENABLE;
+		if (xstrcasestr(s, "UTF8=ACCEPT"))
+			ssn->capabilities |= CAPABILITY_UTF8_ACCEPT;
+		if (xstrcasestr(s, "UTF8=ONLY"))
+			ssn->capabilities |= CAPABILITY_UTF8_ONLY;
 
 		xfree(s);
 	}
@@ -535,7 +541,7 @@ response_list(session *ssn, int tag, char **mboxs, char **folders)
 			s = xstrndup(b + re->pmatch[8].rm_so, strtoul(b +
 			    re->pmatch[7].rm_so, NULL, 10));
 
-		v = reverse_namespace(s, ssn->ns.prefix, ssn->ns.delim);
+		v = reverse_namespace(s, ssn->ns.prefix, ssn->ns.delim, ssn->utf8_accept_enabled);
 		n = strlen(v);
 
 		if (!xstrcasestr(a, "\\NoSelect")) {

--- a/src/session.c
+++ b/src/session.c
@@ -41,6 +41,7 @@ session_init(session *ssn)
 	ssn->capabilities = CAPABILITY_NONE;
 	ssn->ns.prefix = NULL;
 	ssn->ns.delim = '\0';
+	ssn->utf8_accept_enabled = 0;
 }
 
 

--- a/src/session.h
+++ b/src/session.h
@@ -16,6 +16,7 @@ typedef struct session {
 		char *prefix;	/* Namespace prefix. */
 		char delim;	/* Namespace delimiter. */
 	} ns;
+	char utf8_accept_enabled; /* Boolean of UTF8=ACCEPT enabled session */
 } session;
 
 


### PR DESCRIPTION
Imapfilter handles UTF-8 encoding preprending CHARSET 'UTF-8' to queries when options.charset is set to 'UTF-8' in the configuration file.

This seems to work for Mailboxes that are transformed to UTF-7 according to RFC 3501, but not for other queries like the ones sent with send_query('X-GM-RAW ...').

For example:

  C (3): 1015 UID SEARCH CHARSET "UTF-8" ALL SUBJECT "Areté"
  S (3): 1015 BAD Could not parse command
  imapfilter: IMAP (3): 1015 BAD Could not parse command

  or

  C (3): 1016 UID SEARCH CHARSET "UTF-8" ALL X-GM-RAW "label:INBOX Areté"
  S (3): 1016 BAD Could not parse command
  imapfilter: IMAP (3): 1016 BAD Could not parse command

Since GMail accepts UTF-8 for X-GM-RAW queries, and UTF-8 in IMAP is supported since RFC 6855, this implementation of the UTF8=ACCEPT capability makes these queries work. This also makes unnecessary the transcoding into UTF-7 for Mailboxes containing non-ASCII characters when the server accepts UTF-8 conforming to RFC 6855.

I find imapfilter very useful in my everyday mail handling, and it would be nice that UTF-8 could be supported with this or a similar implementation to enable UTF-8 search queries without headaches.