### PR TITLE
table.pack requires at least lua 5.2

### DIFF
--- a/src/auxiliary.lua
+++ b/src/auxiliary.lua
@@ -73,7 +73,7 @@ function recover(commands, retries)
 
     count = 0
     while true do
-        local r = table.pack(pcall(commands))
+        local r = {pcall(commands)}
         if retries == nil or count < retries then
             if r[1] then return table.unpack(r) end
         else


### PR DESCRIPTION
The recover functions uses table.pack, which is not available in lua 5.1