### PR TITLE
Replace Math.pow with `^` for Lua 5.3 support

### DIFF
--- a/src/auxiliary.lua
+++ b/src/auxiliary.lua
@@ -81,7 +81,7 @@ function recover(commands, retries)
         end
         collectgarbage()
         count = count + 1
-        ifsys.sleep(math.min(math.pow(2, count), 60))
+        ifsys.sleep(math.min(2 ^ count, 60))
     end
 end
 


### PR DESCRIPTION
`Math.pow` was deprecated in Lua 5.3 https://www.lua.org/manual/5.3/manual.html#8.2

I didn't check for other Lua 5.3 incompatibilities yet