### PR TITLE
Add Docker pipeline

### DIFF
--- a/.github/workflows/push-docker-image.yaml
+++ b/.github/workflows/push-docker-image.yaml
@@ -1,0 +1,44 @@
+name: Push Docker image
+
+on:
+  push:
+    tags: [ 'v*.*.*' ]
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  main:
+    name: Build and push Docker image
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4.1.7
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3.4.0
+
+      - name: Log into registry ${{ env.REGISTRY }}
+        uses: docker/login-action@v3.2.0
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5.5.1
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+      - name: Build and push Docker image
+        id: build-and-push
+        uses: docker/build-push-action@v6.3.0
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,45 @@
+# Shared layer with dependencies
+FROM alpine:3.20.1 AS shared
+
+## Install shared dependencies
+RUN apk update
+RUN apk add --no-cache openssl
+RUN apk add --no-cache make
+RUN apk add --no-cache lua5.1
+RUN apk add --no-cache pcre2
+
+
+
+# Build layer with dev-dependencies
+FROM shared AS build
+
+## Install build dependencies
+RUN apk add --no-cache openssl-dev
+RUN apk add --no-cache alpine-sdk
+RUN apk add --no-cache lua5.1-dev
+RUN apk add --no-cache pcre2-dev
+
+
+## Build imapfilter
+WORKDIR /dist
+COPY ./ /dist/
+RUN make all
+
+
+
+# Final layer with installed imapfilter
+FROM shared AS final
+
+## Install imapfilter
+COPY --from=build /dist /dist
+WORKDIR /dist
+RUN make install
+
+
+# Clean-up dist
+RUN rm -rf /dist
+
+
+WORKDIR /
+
+ENTRYPOINT [ "imapfilter" ]


### PR DESCRIPTION
Add proper<sup>1</sup> pipeline to build and push a lightweight (based on Alpine) Docker image with imapfilter; I expect it to replase [this](https://hub.docker.com/r/peez/imapfilter) drastically outdated image at DockerHub.

<sup>1</sup> — free and open, with easily verifiable source code.