### PR TITLE
Apply charset option to search queries consistently.

### DIFF
--- a/src/request.c
+++ b/src/request.c
@@ -8,6 +8,7 @@
 #include "session.h"
 #include "buffer.h"
 
+const char *apply_conversion(const char *);
 
 extern options opts;
 
@@ -374,12 +375,15 @@ request_search(session *ssn, const char *criteria, const char *charset, char
 {
 	int t, r;
 
-	if (charset != NULL && *charset != '\0' && !ssn->utf8) {
-		TRY(t = send_request(ssn, "UID SEARCH CHARSET \"%s\" %s",
-		    charset, criteria));
-	} else {
-		TRY(t = send_request(ssn, "UID SEARCH %s", criteria));
-	}
+  if (charset == NULL || *charset == '\0' || !ssn->utf8) {
+  	TRY(t = send_request(ssn, "UID SEARCH %s", apply_conversion(criteria)));
+  } else if (charset != NULL &&
+      strcasecmp(get_option_string("charset"), "UTF-8")) {
+		TRY(t = send_request(ssn, "UID SEARCH CHARSET \"%s\" %s", charset,
+          criteria));
+  } else {
+    TRY(t = send_request(ssn, "UID SEARCH %s", criteria));
+  }
 	TRY(r = response_search(ssn, t, mesgs));
 
 	return r;


### PR DESCRIPTION
In search queries, when using a charset different from US-ASCII in a session with no UTF-8 capability, characters not belonging to the US-ASCII charset need to be converted to UTF-7. If this conversion is not done, characters not belonging to US-ASCII will make the request fail.

For instance, without this patch the search query "Areté" only will succeed using a UTF-8 charset inside a session with UTF-8 capability. It will fail if ssn->uft8 is set to false but the query is written in UTF-8.