### PR TITLE
Add docker

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,53 @@
+---
+name: docker
+
+on:
+  push:
+    branches:
+      - '*'
+    tags:
+      - v*
+  pull_request:
+    branches:
+      - '*'
+  workflow_dispatch: {}
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/setup-qemu-action@v3
+        with:
+          # Spurious segfaults when compiling
+          # https://github.com/docker/setup-qemu-action/issues/188
+          image: tonistiigi/binfmt:qemu-v8.1.5
+      - uses: docker/setup-buildx-action@v3
+
+      - uses: docker/metadata-action@v5
+        id: meta
+        with:
+          flavor: |
+            latest=false
+          images: |
+            name=ghcr.io/${{ github.repository }},enable=${{ github.repository == 'lefcha/imapfilter' }} # publishing to ghcr.io/lefcha/imapfilter
+            name=ghcr.io/${{ github.actor }}/imapfilter,enable=true # publish to the (PR) author's packages
+          tags: |
+            type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v') }} # set latest tag for releases
+            type=semver,pattern={{raw}} # uses git tag as image tag
+            type=ref,event=branch
+            type=ref,event=pr
+            type=sha
+
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: docker/build-push-action@v6
+        with:
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          platforms: linux/amd64,linux/arm64,linux/arm/v7

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,20 @@
+FROM alpine AS builder
+
+RUN apk --no-cache add make gcc lua lua-dev openssl openssl-dev libc-dev pcre pcre-dev pcre2-dev
+
+WORKDIR /build
+
+ADD . /build
+RUN make && make install
+
+FROM alpine
+
+COPY --from=builder /usr/local/bin/imapfilter /usr/local/bin/imapfilter
+COPY --from=builder /usr/local/share/imapfilter /usr/local/share/imapfilter
+
+RUN apk --no-cache add lua lua-dev openssl pcre git \
+    && adduser -D -u 1000 imapfilter
+
+USER imapfilter
+
+ENTRYPOINT ["/usr/local/bin/imapfilter"]


### PR DESCRIPTION
I've been maintaining docker-imapfilter for a couple years, which provides nightly and tagged builds of imapfilter as a docker image:

https://github.com/ntnn/docker-imapfilter
https://hub.docker.com/r/ntnn/imapfilter

I've added pushing to ghcr.io today (see https://github.com/ntnn/docker-imapfilter/pkgs/container/docker-imapfilter) and thought that since this requires no additional setup you might be interested in an official Docker Image. 

Also I'd prefer that docker-imapfilter is a superset of an official Docker Image, rather than building imapfilter from the ground up.

I'd be open to maintain the Dockerfile and GitHub Action so it's not additional work. PRs against the Dockerfile and Action could be automatically assigned to be reviewed by me using a GitHub CODEOWNERS file:
https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners

IIRC that does not require people in CODEOWNERS to be maintainers.

The file would basically be:

```
* @lefcha
Dockerfile @ntnn
.github/workflows/docker.yml @ntnn
```

For the Dockerfile and Action I abriged the ones used in docker-imapfilter:

https://github.com/ntnn/docker-imapfilter/blob/main/Dockerfile
https://github.com/ntnn/docker-imapfilter/blob/main/.github/workflows/image-build.yml

The Action builds also for ARM as this makes the image usable on single board computers like the Raspberry Pi (which is where I run docker-imapfilter on, e.g.).