### PR TITLE
Parse the transfer encoding from the IMAP structure reply

### DIFF
--- a/doc/imapfilter_config.5
+++ b/doc/imapfilter_config.5
@@ -1236,9 +1236,11 @@ that has as keys the parts of the message, and as values a
 .Vt table
 that has one mandatory element, the type
 .Pq Vt string
-of the part, and two optional elements, the size
-.Pq Vt number
-and name
+of the part, and three optional elements, the size
+.Pq Vt number ,
+name
+.Pq Vt string
+and transfer_encoding
 .Pq Vt string
 of the part.
 .El

--- a/src/common.lua
+++ b/src/common.lua
@@ -220,7 +220,10 @@ function _parse_basic(b)
     _parse_space(b)
     _parse_nstring(b)
     _parse_space(b)
-    _parse_string(b)
+    local e = _parse_string(b)
+    if e then
+	    bp['transfer_encoding'] = e:lower()
+    end
     _parse_space(b)
     bp['size'] = _parse_number(b)
     if bp['type']:sub(1, 5):lower() == 'text/' then


### PR DESCRIPTION
Parses the transfer encoding field from the IMAP structure reply,
so that it can be accessed as transfer_encoding on the parts information field.
    
This field will contain the equivalent to the Content-Transfer-Encoding in the
raw multipart text.
    
This makes it possible for filters to automatically choose an appropriate
content decoder instead of relying on heuristics.